### PR TITLE
Replace '<' with unicode equivalent in script tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,22 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2019-XX-XX
 
+## [v5.0.2] 2019-11-26
+
+- [fix] Fix XSS-vulnerability on SearchPage where URL param 'address' was exposed directly to
+  schema, which is just a script tag: <script type="application/ld+json">. On server-side, this
+  could leak malformed HTML through to browsers and made it possible to inject own script tags.
+
+However, CSP prevents any data breach: injected js can't send data to unknonwn 3rd party sites.
+
+NOTE: Check that `REACT_APP_CSP` is in block mode on your production environment. You can read more
+from Flex docs: https://www.sharetribe.com/docs/guides/how-to-set-up-csp-for-ftw/
+[#62](https://github.com/sharetribe/ftw-hourly/pull/62)
+
 - [fix] Add missing translation key EditListingDescriptionPanel.createListingTitle and change link
   name in UserNav. [#62](https://github.com/sharetribe/ftw-hourly/pull/62)
+
+[v5.0.2]: https://github.com/sharetribe/ftw-hourly/compare/v5.0.1...v5.0.2
 
 ## [v5.0.1] 2019-11-22
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "v5.0.1",
+  "version": "v5.0.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -197,7 +197,9 @@ class PageComponent extends Component {
           <meta httpEquiv="Content-Type" content="text/html; charset=UTF-8" />
           <meta httpEquiv="Content-Language" content={intl.locale} />
           {metaTags}
-          <script type="application/ld+json">{schemaArrayJSONString}</script>
+          <script type="application/ld+json">
+            {schemaArrayJSONString.replace(/</g, '\\u003c')}
+          </script>
         </Helmet>
         <CookieConsent />
         <div


### PR DESCRIPTION
Fix XSS-vulnerability on `SearchPage` where URL param 'address' was exposed directly to schema, which is just a script tag: `<script type="application/ld+json">`. On server-side, this could leak malformed HTML through to browsers and made it possible to inject own script tags.

However, CSP prevents any data breach: injected js can't send data to unknonwn 3rd party sites.

**NOTE:** Check that `REACT_APP_CSP` is in block mode on your production environment. You can read more from Flex docs: https://www.sharetribe.com/docs/guides/how-to-set-up-csp-for-ftw/