### PR TITLE
New release v6.5.1 (update v4.4.3 from upstream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,19 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2020-XX-XX
 
+## [v6.5.1] 2020-05-13
+
 - [fix] Check length of `selectedConfigOptions` in `SectionFeaturesMaybe` to choose between one and
   two column layout. [#92](https://github.com/sharetribe/ftw-hourly/pull/90)
+
+### Updates from upstream
+
+This is update from [upstream](https://github.com/sharetribe/ftw-daily): v4.4.3
+
+- [fix] Allow white space on Japanese bank account info. Japan collects bank name and account owner
+  name in addition to routing numbers. [#1287](https://github.com/sharetribe/ftw-daily/pull/1287)
+- [fix] wrongly named default props handleSubmit renamed to onSubmit
+  [#1288](https://github.com/sharetribe/ftw-daily/pull/1288)
 
 ## [v6.5.0] 2020-04-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.js
+++ b/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.js
@@ -9,7 +9,6 @@ import config from '../../config';
 
 import {
   BANK_ACCOUNT_INPUTS,
-  cleanedString,
   formatFieldMessage,
   requiredInputs,
   mapInputsToStripeAccountKeys,
@@ -150,19 +149,16 @@ class TokenInputFieldComponent extends Component {
         return result.token.id;
       })
       .then(token => {
+        // Check if value has changed during async call.
         const changedValues = inputsNeeded.filter(
-          inputType => values[inputType] !== cleanedString(this.state[inputType].value)
+          inputType => values[inputType] !== this.state[inputType].value
         );
         const valuesAreUnchanged = changedValues.length === 0;
 
         // Handle response only if the input values haven't changed
         if (this._isMounted && valuesAreUnchanged) {
           this.setState(prevState => {
-            const errorsClearedFromInputs = inputsNeeded.map(inputType => {
-              const input = prevState[inputType];
-              return { ...input, error: null };
-            });
-            return { ...errorsClearedFromInputs, stripeError: null };
+            return { stripeError: null };
           });
 
           onChange(token);
@@ -181,8 +177,8 @@ class TokenInputFieldComponent extends Component {
   }
 
   handleInputChange(e, inputType, country, intl) {
-    const rawValue = e.target.value;
-    const value = cleanedString(rawValue);
+    const value = e.target.value;
+
     let inputError = null;
 
     // Validate the changed routing number
@@ -194,7 +190,7 @@ class TokenInputFieldComponent extends Component {
 
     // Save changes to the state
     this.setState(prevState => {
-      const input = { ...prevState[inputType], value: rawValue, error: inputError };
+      const input = { ...prevState[inputType], value, error: inputError };
       return {
         [inputType]: input,
         stripeError: null,

--- a/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.util.js
+++ b/src/components/StripeBankAccountTokenInputField/StripeBankAccountTokenInputField.util.js
@@ -231,11 +231,11 @@ export const mapInputsToStripeAccountKeys = (country, values) => {
 
     case 'JP':
       return {
-        bank_name: cleanedString(values[BANK_NAME]),
-        branch_name: cleanedString(values[BRANCH_NAME]),
+        bank_name: values[BANK_NAME],
+        branch_name: values[BRANCH_NAME],
         routing_number: cleanedString(values[BANK_CODE]).concat(values[BRANCH_CODE]),
         account_number: cleanedString(values[ACCOUNT_NUMBER]),
-        account_holder_name: cleanedString(values[ACCOUNT_OWNER_NAME]),
+        account_holder_name: values[ACCOUNT_OWNER_NAME],
       };
 
     case 'MX':

--- a/src/forms/PaymentMethodsForm/PaymentMethodsForm.js
+++ b/src/forms/PaymentMethodsForm/PaymentMethodsForm.js
@@ -283,7 +283,7 @@ PaymentMethodsForm.defaultProps = {
   className: null,
   rootClassName: null,
   inProgress: false,
-  handleSubmit: null,
+  onSubmit: null,
   addPaymentMethodError: null,
   deletePaymentMethodError: null,
   createStripeCustomerError: null,
@@ -294,7 +294,7 @@ PaymentMethodsForm.defaultProps = {
 PaymentMethodsForm.propTypes = {
   formId: string,
   intl: intlShape.isRequired,
-  handleSubmit: func,
+  onSubmit: func,
   addPaymentMethodError: object,
   deletePaymentMethodError: object,
   createStripeCustomerError: object,


### PR DESCRIPTION
- [fix] Check length of `selectedConfigOptions` in `SectionFeaturesMaybe` to choose between one and two column layout. [#92](https://github.com/sharetribe/ftw-hourly/pull/90)

### Updates from upstream

This is update from [upstream](https://github.com/sharetribe/ftw-daily): v4.4.3

- [fix] Allow white space on Japanese bank account info. Japan collects bank name and account owner name in addition to routing numbers. [#1287](https://github.com/sharetribe/ftw-daily/pull/1287)
- [fix] wrongly named default props handleSubmit renamed to onSubmit
  [#1288](https://github.com/sharetribe/ftw-daily/pull/1288)
