### PR TITLE
fix for bug: location is clobbered when you edit filters, change location, edit filters again

### DIFF
--- a/src/containers/SearchPage/MainPanel.js
+++ b/src/containers/SearchPage/MainPanel.js
@@ -117,7 +117,7 @@ class MainPanel extends Component {
 
     return updatedURLParams => {
       const updater = prevState => {
-        const mergedQueryParams = { ...urlQueryParams, ...prevState.currentQueryParams };
+        const mergedQueryParams = { ...prevState.currentQueryParams, ...urlQueryParams };
         return { currentQueryParams: { ...mergedQueryParams, ...updatedURLParams } };
       };
 


### PR DESCRIPTION
It fixes the location clobbering problem. I think the params here were just in the wrong order. 