### PR TITLE
Remove deprecated time zone keys from regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Remove deprecated time zone keys that Node implementation doesn't recongnize anymore.
+  [#124](https://github.com/sharetribe/ftw-hourly/pull/124)
+
 ## [v9.0.0] 2020-11-17
 
 This major release renames all the CSS files. If you have made custom components or customized

--- a/src/components/FieldTimeZoneSelect/FieldTimeZoneSelect.js
+++ b/src/components/FieldTimeZoneSelect/FieldTimeZoneSelect.js
@@ -6,7 +6,7 @@ import { FieldSelect } from '../../components';
 const FieldTimeZoneSelect = props => {
   // IANA database contains irrelevant time zones too.
   const relevantZonesPattern = new RegExp(
-    '^(Africa|America|Antarctica|Asia|Atlantic|Australia|Europe|Indian|Pacific)'
+    '^(Africa|America(?!/(Argentina/ComodRivadavia|Knox_IN|Nuuk))|Antarctica(?!/(DumontDUrville|McMurdo))|Asia(?!/Qostanay)|Atlantic|Australia(?!/(ACT|LHI|NSW))|Europe|Indian|Pacific)'
   );
 
   return (


### PR DESCRIPTION
These time zone keys are removed:

America/Argentina/ComodRivadavia
America/Knox_IN
America/Nuuk
Antarctica/DumontDUrville
Antarctica/McMurdo
Asia/Qostanay
Australia/ACT
Australia/LHI
Australia/NSW

How to check: write out all the keys that moment-timezone returns into a keyArray and run this with node:
```js
keyArray.forEach(key => {
  try {
    new Intl.DateTimeFormat("en-us", { timeZone: key }).format();
  } catch (error) {
    console.log(key);
  }
});
// node --icu-data-dir=node_modules/full-icu icutest.js thisFile.js
```