### PR TITLE
Use dayCountAvailableForBooking config in FieldDateAndTimeInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Use dayCountAvailableForBooking config instead of hard-coded value in FieldDateAndTimeInput
+  so that it matches the date range that is used in react-dates components.
+  [#129](https://github.com/sharetribe/ftw-hourly/pull/129)
 - [fix] Use default timezone when fetching availability exceptions if availabilityPlan and
   information about listing's timezone doesn't exist yet.
   [#130](https://github.com/sharetribe/ftw-hourly/pull/130)

--- a/src/config.js
+++ b/src/config.js
@@ -52,8 +52,11 @@ const enableAvailability = process.env.REACT_APP_AVAILABILITY_ENABLED === 'true'
 
 // A maximum number of days forwards during which a booking can be made.
 // This is limited due to Stripe holding funds up to 90 days from the
-// moment they are charged. Also note that available time slots can only
-// be fetched for 180 days in the future.
+// moment they are charged:
+// https://stripe.com/docs/connect/account-balances#holding-funds
+//
+// See also the API reference for querying time slots:
+// https://www.sharetribe.com/api-reference/marketplace.html#query-time-slots
 const dayCountAvailableForBooking = 90;
 
 // To pass environment variables to the client app in the build

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { func, object, string } from 'prop-types';
 import classNames from 'classnames';
+import config from '../../config';
 import { intlShape } from '../../util/reactIntl';
 import {
   getStartHours,
@@ -28,7 +29,16 @@ import NextMonthIcon from './NextMonthIcon';
 import PreviousMonthIcon from './PreviousMonthIcon';
 import css from './FieldDateAndTimeInput.module.css';
 
-const MAX_TIME_SLOTS_RANGE = 180;
+// MAX_TIME_SLOTS_RANGE is the maximum number of days forwards during which a booking can be made.
+// This is limited due to Stripe holding funds up to 90 days from the
+// moment they are charged:
+// https://stripe.com/docs/connect/account-balances#holding-funds
+//
+// See also the API reference for querying time slots:
+// https://www.sharetribe.com/api-reference/marketplace.html#query-time-slots
+
+const MAX_TIME_SLOTS_RANGE = config.dayCountAvailableForBooking;
+
 const TODAY = new Date();
 
 const endOfRange = (date, timeZone) => {


### PR DESCRIPTION
Use dayCountAvailableForBooking config instead of hard-coded value in FieldDateAndTimeInput so that it matches the date range that is used in react-dates components. 

Earlier the dayCountAvailableForBooking was set to 90 but the MAX_TIME_SLOTS_RANGE was 180 and the calendar looked broken because after the first 3 months the timeslots appeared as blocked. Also, if you selected the date far enough in the future, checking the timeslots broke and all the dates seem to be available. 

![field-date-and-time-old](https://user-images.githubusercontent.com/9502221/103280472-2c9ab780-49d9-11eb-86e1-6d2f6228e478.gif)

If the dayCountAvailableForBooking and MAX_TIME_SLOTS_RANGE is the same, showing the timeslots works correctly. Here's both 90 and 180 days options:
![field-date-and-time-new-90](https://user-images.githubusercontent.com/9502221/103280539-5358ee00-49d9-11eb-9cf4-987faa80efbb.gif)
![field-date-and-time-new-180](https://user-images.githubusercontent.com/9502221/103280546-58b63880-49d9-11eb-8e7c-e7965311831d.gif)

And since there's the limitation that by default Stripe is holding funds up to 90 days from the moment they are charged, I think keeping the default range in 90 would be the best solution. 
