### PR TITLE
Fix error on EditListingPage when availabilityPlan doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Use default timezone when fetching availability exceptions if availabilityPlan and
+  information about listing's timezone doesn't exist yet.
+  [#130](https://github.com/sharetribe/ftw-hourly/pull/130)
+
 ## [v9.2.0] 2020-12-16
 
 ### Updates from upstream (FTW-daily v7.2.0)


### PR DESCRIPTION
When the listing is created, there's a moment when the availability plan doesn't exist yet until the user completes the availability tab. It's possible to add availability exceptions before the availability plan, so we need to use the default timezone (from browser or Etc/UTC) when fetching the availability exceptions if the plan doesn't exist yet. Otherwise, there would be an error in loadData function. 