### PR TITLE
Fix error on selecting start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2020-XX-XX
 
+- [fix] Handle changing the start time in BookingTimeForm so that it doesn't cause error for
+  fetching the lineItems. [#143](https://github.com/sharetribe/ftw-hourly/pull/143)
+
 ## [v10.1.1] 2021-04-20
 
 - [fix] currency for Poland (PLN) [#140](https://github.com/sharetribe/ftw-hourly/pull/140)
 
 ### Updates from upstream (FTW-daily v8.1.0)
+
 - [change] Update jose to v3.11.4 [#1433](https://github.com/sharetribe/ftw-daily/pull/1433)
 - [add] Update fr.json, es.json and partially de.json
   [#1431](https://github.com/sharetribe/ftw-daily/pull/1431)
@@ -36,6 +40,7 @@ https://github.com/sharetribe/flex-template-web/
 ## [v10.1.0] 2021-03-11
 
 ### Updates from upstream (FTW-daily v8.1.0)
+
 - [change] Specify required Node.js versions in package.json and update the node version used in
   CircleCI. Currently, the required Node.js version comes from
   [jose](https://github.com/panva/jose#runtime-support-matrix) package which is used with social

--- a/src/forms/BookingTimeForm/BookingTimeForm.js
+++ b/src/forms/BookingTimeForm/BookingTimeForm.js
@@ -37,7 +37,9 @@ export class BookingTimeFormComponent extends Component {
     const listingId = this.props.listingId;
     const isOwnListing = this.props.isOwnListing;
 
-    if (bookingStartTime && bookingEndTime && !this.props.fetchLineItemsInProgress) {
+    const isSameTime = bookingStartTime === bookingEndTime;
+
+    if (bookingStartTime && bookingEndTime && !isSameTime && !this.props.fetchLineItemsInProgress) {
       this.props.onFetchTransactionLineItems({
         bookingData: { startDate, endDate },
         listingId,

--- a/src/forms/BookingTimeForm/BookingTimeForm.js
+++ b/src/forms/BookingTimeForm/BookingTimeForm.js
@@ -37,6 +37,8 @@ export class BookingTimeFormComponent extends Component {
     const listingId = this.props.listingId;
     const isOwnListing = this.props.isOwnListing;
 
+    // We expect values bookingStartTime and bookingEndTime to be strings
+    // which is the default case when the value has been selected through the form
     const isSameTime = bookingStartTime === bookingEndTime;
 
     if (bookingStartTime && bookingEndTime && !isSameTime && !this.props.fetchLineItemsInProgress) {

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -139,7 +139,7 @@ const getAllTimeValues = (
   const startTime = selectedStartTime
     ? selectedStartTime
     : startTimes.length > 0 && startTimes[0] && startTimes[0].timestamp
-    ? startTimes[0].timestamp
+    ? startTimes[0].timestamp.toString()
     : null;
 
   const startTimeAsDate = startTime ? timestampToDate(startTime) : null;
@@ -160,7 +160,9 @@ const getAllTimeValues = (
 
   const endTimes = getAvailableEndTimes(intl, timeZone, startTime, endDate, selectedTimeSlot);
   const endTime =
-    endTimes.length > 0 && endTimes[0] && endTimes[0].timestamp ? endTimes[0].timestamp : null;
+    endTimes.length > 0 && endTimes[0] && endTimes[0].timestamp
+      ? endTimes[0].timestamp.toString()
+      : null;
 
   return { startTime, endDate, endTime, selectedTimeSlot };
 };

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -136,6 +136,10 @@ const getAllTimeValues = (
         getTimeSlots(timeSlots, startDate, timeZone)
       );
 
+  // Value selectedStartTime is a string when user has selected it through the form.
+  // That's why we need to convert also the timestamp we use as a default
+  // value to string for consistency. This is expected later when we
+  // want to compare the sartTime and endTime.
   const startTime = selectedStartTime
     ? selectedStartTime
     : startTimes.length > 0 && startTimes[0] && startTimes[0].timestamp
@@ -159,6 +163,10 @@ const getAllTimeValues = (
   );
 
   const endTimes = getAvailableEndTimes(intl, timeZone, startTime, endDate, selectedTimeSlot);
+
+  // We need to convert the timestamp we use as a default value
+  // for endTime to string for consistency. This is expected later when we
+  // want to compare the sartTime and endTime.
   const endTime =
     endTimes.length > 0 && endTimes[0] && endTimes[0].timestamp
       ? endTimes[0].timestamp.toString()


### PR DESCRIPTION
Currently, there's an error if you select a start time and then change the start time to start earlier than the original selection. This bug was introduced most likely when the FTW-hourly was updated to use the new pricing actions. The reason for this error is that both the start time and end time that is passed to the fetchLineItems function are the same and the quantity can't be calculated. 

This most likely happens, because when the startTime is updated and `onBookingStartTimeChange` is called, `form.change` call happens for endTime before the startTime actually changes. This is why the `handleOnChange` function of the BookingTimeForm is first called with the new endTime and old startTime which happen to be the same value.

I think the simplest solution is to check the startTime and endTime on the `handleOnChange` function and then fetch the line items only if these values are not the same.

Currently: 
![bookingTimeFormOld](https://user-images.githubusercontent.com/9502221/113875569-94725280-97bf-11eb-9e7b-be4ccff85e35.gif)


After the fix:
![BookingTImeFormNew](https://user-images.githubusercontent.com/9502221/113875590-9b996080-97bf-11eb-8f5a-aec01f45eb6d.gif)
