### PR TITLE
Fix bug wrong current month after leaving date input with a month is not current month

### DIFF
--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -482,6 +482,7 @@ class FieldDateAndTimeInput extends Component {
               useMobileMargins
               showErrorMessage={false}
               validate={bookingDateRequired('Required')}
+              onClose={() => this.setState({currentMonth: getMonthStartInTimeZone(TODAY, this.props.timeZone)})}
             />
           </div>
         </div>


### PR DESCRIPTION
The PR fixes a bug of the current month state. 
Scenario: A bug occurs when a user is changing the month and then close the DatePicker without choosing any exact date. but now the ```state.currentMonth``` is not reset. If the user try to reopen the calendar after then, the state still remains the month before closing. Therefore, the currentMonth of DatePicker and the state don't match each other and it results in the bug where the timeslots are fetched incorrectly.