### PR TITLE
From PR: Fix wrong current month after leaving date input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ https://github.com/sharetribe/flex-template-web/
 
 ## [v10.2.0] 2021-08-06
 
+- [fix] Fix bug wrong current month after leaving date input with wrong month
+  [#161](https://github.com/sharetribe/ftw-hourly/pull/161)
 - [fix] Handle changing the start time in BookingTimeForm so that it doesn't cause error for
   fetching the lineItems. [#143](https://github.com/sharetribe/ftw-hourly/pull/143)
 

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -482,7 +482,9 @@ class FieldDateAndTimeInput extends Component {
               useMobileMargins
               showErrorMessage={false}
               validate={bookingDateRequired('Required')}
-              onClose={() => this.setState({currentMonth: getMonthStartInTimeZone(TODAY, this.props.timeZone)})}
+              onClose={() =>
+                this.setState({ currentMonth: getMonthStartInTimeZone(TODAY, this.props.timeZone) })
+              }
             />
           </div>
         </div>

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -482,6 +482,7 @@ class FieldDateAndTimeInput extends Component {
               useMobileMargins
               showErrorMessage={false}
               validate={bookingDateRequired('Required')}
+              onClose={() => this.setState({currentMonth: getMonthStartInTimeZone(TODAY, this.props.timeZone)})}
             />
           </div>
         </div>


### PR DESCRIPTION
Cherry-picked the fix from https://github.com/sharetribe/ftw-hourly/pull/158