### PR TITLE
Fix old clearing of EditListingPage.state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2021-XX-XX
 
+- [fix] EditListingPage: fix an old bug (before we had draft-listing state the update flow was
+  different and we cleared state after a sequence of API calls)
+  [#164](https://github.com/sharetribe/ftw-hourly/pull/164)
+
 ## [v10.2.0] 2021-08-06
 
 - [fix] Fix bug wrong current month after leaving date input with wrong month

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -167,7 +167,7 @@ export default function reducer(state = initialState, action = {}) {
     case SHOW_LISTINGS_REQUEST:
       return { ...state, showListingsError: null };
     case SHOW_LISTINGS_SUCCESS:
-      return { ...initialState };
+      return state;
 
     case SHOW_LISTINGS_ERROR:
       // eslint-disable-next-line no-console
@@ -378,7 +378,6 @@ export function requestShowListing(actionPayload) {
       .then(response => {
         // EditListingPage fetches new listing data, which also needs to be added to global data
         dispatch(addMarketplaceEntities(response));
-        // In case of success, we'll clear state.EditListingPage (user will be redirected away)
         dispatch(showListingsSuccess(response));
         return response;
       })


### PR DESCRIPTION
This clearing doesn't make any sense with current wizard-flow that uses draft-state. (In old flow, listing creation flow had only one call to API and show request was called after that.)