### PR TITLE
Fix calendar timeslots and entries not showing on month change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ https://github.com/sharetribe/flex-template-web/
 
 ## Upcoming version 2021-XX-XX
 
+- [fix] When changing calendar month, the current month was not set correctly. (Selecting date
+  closes the react-dates calendar and today was saved instead of currently selected one.)
+  [#176](https://github.com/sharetribe/ftw-hourly/pull/176)
 - [fix] Temporarily disallow Node v17, since it causes issues with dependencies.
   [#173](https://github.com/sharetribe/ftw-hourly/pull/173)
 - [change] Use en-US defaults for all time formatting. This changes the format from "23:00" to

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -482,7 +482,7 @@ class FieldDateAndTimeInput extends Component {
               useMobileMargins
               showErrorMessage={false}
               validate={bookingDateRequired('Required')}
-              onClose={event => 
+              onClose={event =>
                 this.setState({
                   currentMonth: getMonthStartInTimeZone(event?.date ?? TODAY, this.props.timeZone),
                 })

--- a/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/forms/BookingTimeForm/FieldDateAndTimeInput.js
@@ -482,8 +482,10 @@ class FieldDateAndTimeInput extends Component {
               useMobileMargins
               showErrorMessage={false}
               validate={bookingDateRequired('Required')}
-              onClose={() =>
-                this.setState({ currentMonth: getMonthStartInTimeZone(TODAY, this.props.timeZone) })
+              onClose={event => 
+                this.setState({
+                  currentMonth: getMonthStartInTimeZone(event?.date ?? TODAY, this.props.timeZone),
+                })
               }
             />
           </div>


### PR DESCRIPTION
Essentially just PR #175 formatted and changelog entry added.
This pull request addresses the issue #174 and #165

Essentially checks the date given here:
https://github.com/airbnb/react-dates/blob/master/src/components/DayPickerSingleDateController.jsx#L380